### PR TITLE
feat: flag to prevent double height optimizer

### DIFF
--- a/src/components/DashKit/DashKit.tsx
+++ b/src/components/DashKit/DashKit.tsx
@@ -32,6 +32,7 @@ interface DashKitDefaultProps {
     overlayControls?: Record<string, OverlayControlItem[]>;
     noOverlay?: boolean;
     draggableHandleClassName?: string;
+    _preventDoubleCompact?: boolean;
 }
 
 export interface DashKitProps extends DashKitGeneralProps, Partial<DashKitDefaultProps> {}

--- a/src/components/DashKit/DashKit.tsx
+++ b/src/components/DashKit/DashKit.tsx
@@ -32,7 +32,7 @@ interface DashKitDefaultProps {
     overlayControls?: Record<string, OverlayControlItem[]>;
     noOverlay?: boolean;
     draggableHandleClassName?: string;
-    _preventDoubleCompact?: boolean;
+    _EXPERIMENTAL_preventDoubleCompact?: boolean;
 }
 
 export interface DashKitProps extends DashKitGeneralProps, Partial<DashKitDefaultProps> {}

--- a/src/components/DashKit/__stories__/DashKitShowcase.tsx
+++ b/src/components/DashKit/__stories__/DashKitShowcase.tsx
@@ -20,6 +20,7 @@ type DashKitDemoState = {
     lastAction: string;
     customControlsActionData: number;
     showCustomMenu: boolean;
+    _preventDoubleCompact: boolean;
 };
 
 export class DashKitShowcase extends React.Component<{}, DashKitDemoState> {
@@ -37,6 +38,7 @@ export class DashKitShowcase extends React.Component<{}, DashKitDemoState> {
         lastAction: 'Нет',
         customControlsActionData: 0,
         showCustomMenu: true,
+        _preventDoubleCompact: false,
     };
 
     private dashKitRef = React.createRef<DashKit>();
@@ -130,6 +132,7 @@ export class DashKitShowcase extends React.Component<{}, DashKitDemoState> {
                         settings={this.state.settings}
                         ref={this.dashKitRef}
                         overlayControls={controls}
+                        _preventDoubleCompact={this.state._preventDoubleCompact}
                     />
                 </Demo.Row>
             </Demo>

--- a/src/components/DashKit/__stories__/DashKitShowcase.tsx
+++ b/src/components/DashKit/__stories__/DashKitShowcase.tsx
@@ -20,7 +20,7 @@ type DashKitDemoState = {
     lastAction: string;
     customControlsActionData: number;
     showCustomMenu: boolean;
-    _preventDoubleCompact: boolean;
+    _EXPERIMENTAL_preventDoubleCompact: boolean;
 };
 
 export class DashKitShowcase extends React.Component<{}, DashKitDemoState> {
@@ -38,7 +38,7 @@ export class DashKitShowcase extends React.Component<{}, DashKitDemoState> {
         lastAction: 'Нет',
         customControlsActionData: 0,
         showCustomMenu: true,
-        _preventDoubleCompact: false,
+        _EXPERIMENTAL_preventDoubleCompact: false,
     };
 
     private dashKitRef = React.createRef<DashKit>();
@@ -132,7 +132,9 @@ export class DashKitShowcase extends React.Component<{}, DashKitDemoState> {
                         settings={this.state.settings}
                         ref={this.dashKitRef}
                         overlayControls={controls}
-                        _preventDoubleCompact={this.state._preventDoubleCompact}
+                        _EXPERIMENTAL_preventDoubleCompact={
+                            this.state._EXPERIMENTAL_preventDoubleCompact
+                        }
                     />
                 </Demo.Row>
             </Demo>

--- a/src/hocs/withContext.js
+++ b/src/hocs/withContext.js
@@ -26,6 +26,7 @@ export function withContext(Component) {
             forwardedMetaRef: PropTypes.object,
             noOverlay: PropTypes.bool,
             draggableHandleClassName: PropTypes.string,
+            _preventDoubleCompact: PropTypes.bool,
         };
 
         // так как мы не хотим хранить параметры виджета с активированной автовысотой в сторе и на сервере, актуальный
@@ -73,15 +74,19 @@ export function withContext(Component) {
                 }
             });
 
+            // [experimental] if the _prevent Double Compact is enabled, then skip recalculate layout with auto height
+
             // после того, как у виждета активировали автовысоту и его параметр "h" изменился, это приведёт, также, и к
             // изменению параметра (координаты) "y" у элементов расположенных под ним, поэтому, после того, как
             // значения параметра "h" виджетов с активированной автовысотой были изменены, необходимо изменить и
             // координату "y" виджетов расположенных ниже
-            const compactedLayout = gridLayoutUtils.compact(
-                currentLayout,
-                LAYOUT_COMPACTING_TYPE,
-                this.props.registerManager.gridLayout.cols,
-            );
+            const compactedLayout = this.props._preventDoubleCompact
+                ? currentLayout
+                : gridLayoutUtils.compact(
+                      currentLayout,
+                      LAYOUT_COMPACTING_TYPE,
+                      this.props.registerManager.gridLayout.cols,
+                  );
 
             const newConfig = UpdateManager.updateLayout({
                 layout: compactedLayout,

--- a/src/hocs/withContext.js
+++ b/src/hocs/withContext.js
@@ -26,7 +26,7 @@ export function withContext(Component) {
             forwardedMetaRef: PropTypes.object,
             noOverlay: PropTypes.bool,
             draggableHandleClassName: PropTypes.string,
-            _preventDoubleCompact: PropTypes.bool,
+            _EXPERIMENTAL_preventDoubleCompact: PropTypes.bool,
         };
 
         // так как мы не хотим хранить параметры виджета с активированной автовысотой в сторе и на сервере, актуальный
@@ -80,7 +80,7 @@ export function withContext(Component) {
             // изменению параметра (координаты) "y" у элементов расположенных под ним, поэтому, после того, как
             // значения параметра "h" виджетов с активированной автовысотой были изменены, необходимо изменить и
             // координату "y" виджетов расположенных ниже
-            const compactedLayout = this.props._preventDoubleCompact
+            const compactedLayout = this.props._EXPERIMENTAL_preventDoubleCompact
                 ? currentLayout
                 : gridLayoutUtils.compact(
                       currentLayout,


### PR DESCRIPTION
New experimental flag `_preventDoubleCompact` to disable double invocation of `gridLayoutUtils.compact` method, one from react-grid-layout library, second from `_onLayoutChange` callback