### PR TITLE
feat: add custom dropdown menu item filter in edit mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,7 +287,7 @@ type ItemsStateAndParams = StateAndParamsMeta & ItemsStateAndParamsBase;
 
 ### Menu
 
-You can specify custom dashkit widget overlay menu in edit mode
+You can specify custom DashKit widget overlay menu in edit mode
 
 ```ts
 type MenuItem = {
@@ -303,13 +303,6 @@ type MenuItem = {
 // use array of menu items in settings
 DashKit.setSettings({menu: [] as Array<MenuItem>});
 ```
-
-Each menu item object:
-
-1. `defaultGlobalParams`
-2. Default widget parameters `item.default`
-3. `globalParams`
-4. Parameters from [itemsStateAndParams](#itemsStateAndParams) according to the queue.
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Before using `DashKit` as a react component, it must be configured.
 
 - DashKit.setSettings
 
-  Used for global DashKit settings (such as margins between widgets and default widget sizes)
+  Used for global DashKit settings (such as margins between widgets, default widget sizes and widget overlay menu)
 
   ```js
   import {DashKit} from '@yandex-cloud/dashkit';
@@ -65,6 +65,7 @@ Before using `DashKit` as a react component, it must be configured.
   DashKit.setSettings({
     gridLayout: {margin: [8, 8]},
     isMobile: true,
+    // menu: [] as Array<MenuItem>,
   });
   ```
 
@@ -283,6 +284,32 @@ interface ItemsStateAndParamsBase {
 ```ts
 type ItemsStateAndParams = StateAndParamsMeta & ItemsStateAndParamsBase;
 ```
+
+### Menu
+
+You can specify custom dashkit widget overlay menu in edit mode
+
+```ts
+type MenuItem = {
+  id: string; // uniq id
+  title?: string; // string title
+  icon?: ReactNode; // node of icon
+  iconSize?: number | string; // icon size in px as number or as string with units
+  handler?: (item: ConfigItem) => void; // custom item action handler
+  visible?: (item: ConfigItem) => boolean; // optional visibility handler for filtering menu items
+  className?: string; // custom class property
+};
+
+// use array of menu items in settings
+DashKit.setSettings({menu: [] as Array<MenuItem>});
+```
+
+Each menu item object:
+
+1. `defaultGlobalParams`
+2. Default widget parameters `item.default`
+3. `globalParams`
+4. Parameters from [itemsStateAndParams](#itemsStateAndParams) according to the queue.
 
 ## Development
 

--- a/src/components/OverlayControls/OverlayControls.tsx
+++ b/src/components/OverlayControls/OverlayControls.tsx
@@ -218,7 +218,7 @@ class OverlayControls extends React.Component<OverlayControlsProps> {
                   const itemHandler = item.handler;
 
                   const itemAction =
-                      itemHandler && typeof itemHandler === 'function'
+                      typeof itemHandler === 'function'
                           ? () => itemHandler(this.props.configItem)
                           : this.getDropDownMenuItemConfig(item.id)?.action || (() => {});
 

--- a/src/components/OverlayControls/OverlayControls.tsx
+++ b/src/components/OverlayControls/OverlayControls.tsx
@@ -47,6 +47,7 @@ export interface OverlayCustomControlItem {
     icon?: MenuItemProps['icon'];
     iconSize?: number | string;
     handler?: (item: ConfigItem) => void;
+    visible?: (item: ConfigItem) => boolean;
     className?: string;
 }
 
@@ -209,13 +210,22 @@ class OverlayControls extends React.Component<OverlayControlsProps> {
                   if (typeof item === 'string') {
                       return null;
                   }
+                  // custom menu dropdown item filter
+                  if (item.visible && !item.visible(this.props.configItem)) {
+                      return null;
+                  }
+
+                  const itemHandler = item.handler;
+
+                  const itemAction =
+                      itemHandler && typeof itemHandler === 'function'
+                          ? () => itemHandler(this.props.configItem)
+                          : this.getDropDownMenuItemConfig(item.id)?.action || (() => {});
+
                   return {
                       text: item.title || i18n(item.id),
                       icon: item.icon,
-                      action:
-                          typeof item.handler === 'function'
-                              ? item.handler
-                              : this.getDropDownMenuItemConfig(item.id)?.action || (() => {}),
+                      action: itemAction,
                       className: item.className,
                   };
               });


### PR DESCRIPTION
implement new feature for filtering menu item in edit mode by custom `visible` handler

```tsx
type MenuItem = {
  visible?: (item: ConfigItem) => boolean; // optional visibility handler for filtering menu items
};
```

also fix dropdown menu item handler with `ConfigItem` as callback params